### PR TITLE
Changed default item template to start from 1 rather than 0.

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -321,7 +321,7 @@ angular.module("umbraco").factory('innerContentService', [
                 return itm2.icContentTypeAlias === itm.icContentTypeAlias;
             });
 
-            var nameTemplate = contentType.nameTemplate || "Item {{$index}}";
+            var nameTemplate = contentType.nameTemplate || "Item {{$index+1}}";
             var nameExp = $interpolate(nameTemplate);
 
             if (nameExp) {


### PR DESCRIPTION
Hey folks. This is a really, really small change that gives the default item template a more user friendly name. "Item 0" looked a little odd.