### PR TITLE
Ability to change the label used when displaying a Doc Type

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -283,6 +283,11 @@ angular.module("umbraco").factory('innerContentService', [
                     }
                 }
 
+                // Overwrite Umbraco Content Type label with alternate configured value
+                if (scaffold.contentTypeName && contentType.docTypeAltLabel) {
+                    scaffold.contentTypeName = contentType.docTypeAltLabel;
+                }
+
                 // Store the scaffold object
                 scaffolds.push(scaffold);
 

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.doctypepicker.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.doctypepicker.html
@@ -8,6 +8,9 @@
                         Document Type
                     </th>
                     <th>
+                        Document Type Alt Label
+                    </th>
+                    <th>
                         Name Template
                     </th>
                     <th class="td-min" ng-show="model.value.length > 1" />
@@ -20,6 +23,9 @@
                         <select id="{{model.alias}}_doctype_select"
                             ng-options="dt.alias as dt.name for dt in model.docTypes | orderBy: 'name'"
                             ng-model="config.icContentTypeAlias" required></select>
+                    </td>
+                    <td>
+                        <input type="text" ng-model="config.docTypeAltLabel" />
                     </td>
                     <td>
                         <input type="text" ng-model="config.nameTemplate" />


### PR DESCRIPTION
Hey folks, me again :) this is more of a quality of life change. Not sure about my implementation.

Basically, say you have a series of Doc Types used in Stacked Content; "Twitter Tweet Module", "Facebook Post Module" & "Instagram Post Module" but instead of displaying those names when adding new content you wanted to display; "Twitter Tweet", "Facebook Post" & "Instagram Post".

It might be useful in cases where you don't want to or can't change your Document Type name to meet client friendly naming conventions.