### PR TITLE
Adds "Use Internal Action Filter" Action Filter

### DIFF
--- a/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
+++ b/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
@@ -89,6 +89,7 @@
     <Compile Include="PropertyEditors\InnerContentPropertyValueEditorWrapper.cs" />
     <Compile Include="PropertyEditors\SimpleInnerContentPropertyValueEditor.cs" />
     <Compile Include="Web\Controllers\InnerContentApiController.cs" />
+    <Compile Include="Web\WebApi\Filters\UseInternalActionFilterAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
+++ b/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
 using System.Web.Http.ModelBinding;
+using Our.Umbraco.InnerContent.Web.WebApi.Filters;
 using Umbraco.Web.Editors;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
@@ -73,6 +74,7 @@ namespace Our.Umbraco.InnerContent.Web.Controllers
         }
 
         [HttpGet]
+        [UseInternalActionFilter("Umbraco.Web.WebApi.Filters.OutgoingEditorModelEventAttribute", onActionExecuted: true)]
         public ContentItemDisplay GetContentTypeScaffoldByGuid(Guid guid)
         {
             var contentType = Services.ContentTypeService.GetContentType(guid);

--- a/src/Our.Umbraco.InnerContent/Web/WebApi/Filters/UseInternalActionFilterAttribute.cs
+++ b/src/Our.Umbraco.InnerContent/Web/WebApi/Filters/UseInternalActionFilterAttribute.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+
+namespace Our.Umbraco.InnerContent.Web.WebApi.Filters
+{
+    /// <summary>
+    /// Uses reflection to enable the use of an action filter that has been marked as internal by a 3rd party assembly.
+    /// </summary>
+    /// <remarks>
+    /// The reason for developing this attribute was that we wanted to use Umbraco's `OutgoingEditorModelEvent` action filter.
+    /// The irony of this is that we've marked this attribute class as internal ourselves.
+    /// </remarks>
+    internal class UseInternalActionFilterAttribute : ActionFilterAttribute
+    {
+        private string _fullyQualifiedTypeName;
+        private Type _internalType;
+        private object _internalInstance;
+        private bool _runOnActionExecuting { get; set; }
+        private bool _runOnActionExecuted { get; set; }
+
+        public UseInternalActionFilterAttribute(
+            string fullyQualifiedTypeName,
+            bool onActionExecuting = false,
+            bool onActionExecuted = false)
+        {
+            _fullyQualifiedTypeName = fullyQualifiedTypeName;
+            _runOnActionExecuting = onActionExecuting;
+            _runOnActionExecuted = onActionExecuted;
+        }
+
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            if (_runOnActionExecuting)
+            {
+                InvokeInternalAction("OnActionExecuting", new[] { actionContext });
+            }
+
+            base.OnActionExecuting(actionContext);
+        }
+
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            if (_runOnActionExecuted)
+            {
+                InvokeInternalAction("OnActionExecuted", new[] { actionExecutedContext });
+            }
+
+            base.OnActionExecuted(actionExecutedContext);
+        }
+
+        private void InvokeInternalAction(string methodName, params object[] parameters)
+        {
+            try
+            {
+                if (_internalType == null && string.IsNullOrWhiteSpace(_fullyQualifiedTypeName) == false)
+                {
+                    _internalType = TypeFinder.GetTypeByName(_fullyQualifiedTypeName);
+                }
+
+                if (_internalType != null)
+                {
+                    var method = _internalType.GetMethod(methodName);
+                    if (method != null)
+                    {
+                        if (_internalInstance == null)
+                        {
+                            _internalInstance = Activator.CreateInstance(_internalType);
+                        }
+
+                        if (_internalInstance != null)
+                        {
+                            method.Invoke(_internalInstance, parameters);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<UseInternalActionFilterAttribute>(methodName, ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
With PR #10, we've had to swap out our calls to `contentResource.getScaffold` resource, as that doesn't work with a Guid ID.
However in doing that we actually lose an Umbraco goodie, namely that the api data is passed through the `OutgoingEditorModelEvent` action filter

https://github.com/umbraco/Umbraco-CMS/blob/release-7.4.0/src/Umbraco.Web/Editors/ContentController.cs#L144

Unfortunately the `OutgoingEditorModelEvent` attribute is marked as internal, so we can't use it directly.

https://github.com/umbraco/Umbraco-CMS/blob/release-7.4.0/src/Umbraco.Web/WebApi/Filters/OutgoingEditorModelEventAttribute.cs

I initially added an action filter that used reflection to only call the `OutgoingEditorModelEventAttribute.OnActionExecuted` method.
But then abstracted it to handle any other action filters that are marked as internal.

---

My personal reason for doing this, is that I often use markdown in property descriptions, which no longer worked after PR #10.  (For reference, [see my gist for rendering markdown](https://gist.github.com/leekelleher/be0b93c069c1c40633a826e63aaaf7b1)).

@mattbrailsford What do you think? Too hacky?