### PR TITLE
Self-heals "single-item mode" items when upgrading to v1.1.0

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -361,7 +361,8 @@ angular.module("umbraco").factory('innerContentService', [
         var self = {};
 
         var getScaffold = function (contentType) {
-            return icResources.getContentTypeScaffoldByGuid(contentType.icContentTypeGuid).then(function (scaffold) {
+
+            var processScaffold = function (scaffold) {
 
                 // remove all tabs except the specified tab
                 if (contentType.hasOwnProperty("icTabAlias")) {
@@ -385,7 +386,11 @@ angular.module("umbraco").factory('innerContentService', [
 
                 return scaffold;
 
-            });
+            };
+
+            return contentType.hasOwnProperty("icContentTypeGuid")
+                ? icResources.getContentTypeScaffoldByGuid(contentType.icContentTypeGuid).then(processScaffold)
+                : contentResource.getScaffold(-20, contentType.icContentTypeAlias).then(processScaffold);
         }
 
         self.populateName = function (itm, idx, contentTypes) {


### PR DESCRIPTION
When upgrading to v1.1.0 (currently in alpha), the JS code will attempt self-heal the data-type and property-data values,
(note this is on the client-side and data-types would need to be re-saved for this to take effect).

However for any empty "single-item mode" items, the content-type's scaffold is requested on-load.
But the JS code is only looking to use the `icContentTypeGuid` value, whereas the property's data-type only has the `icContentTypeAlias` value available.

One fix is to re-save the property's data-type, job done - however if a user forgets to do this, then they will see an error in the Content section.

This patch checks if the `icContentTypeGuid` value is available, otherwise falls back on the old `icContentTypeAlias` value.