### PR TITLE
Ensures ContentType GUIDs

### DIFF
--- a/src/Our.Umbraco.InnerContent/Bootstrap.cs
+++ b/src/Our.Umbraco.InnerContent/Bootstrap.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using Newtonsoft.Json;
+using Our.Umbraco.InnerContent.Helpers;
 using Umbraco.Core;
-using Umbraco.Core.Cache;
 using Umbraco.Core.Sync;
 using Umbraco.Web.Cache;
 
@@ -47,14 +47,8 @@ namespace Our.Umbraco.InnerContent
                 var contentTypes = applicationContext.Services.ContentTypeService.GetAllContentTypes(ids);
                 foreach (var contentType in contentTypes)
                 {
-                    // Only clear the guid => alias cache if the content-types alias has changed
-                    var key = string.Format(InnerContentConstants.ContentTypeAliasByGuidCacheKey, contentType.Key);
-                    var alias = applicationContext.ApplicationCache.StaticCache.GetCacheItem<string>(key, () => contentType.Alias);
-                    if (alias != null && alias != contentType.Alias)
-                    {
-                        applicationContext.ApplicationCache.StaticCache.ClearCacheItem(key);
-                        applicationContext.ApplicationCache.StaticCache.GetCacheItem<string>(key, () => contentType.Alias);
-                    }
+                    ContentTypeCacheHelper.TryRemove(contentType);
+                    ContentTypeCacheHelper.TryAdd(contentType);
                 }
             };
         }

--- a/src/Our.Umbraco.InnerContent/Helpers/ContentTypeCacheHelper.cs
+++ b/src/Our.Umbraco.InnerContent/Helpers/ContentTypeCacheHelper.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Our.Umbraco.InnerContent.Helpers
+{
+    internal static class ContentTypeCacheHelper
+    {
+        private static readonly ConcurrentDictionary<Guid, string> Forward = new ConcurrentDictionary<Guid, string>();
+        private static readonly ConcurrentDictionary<string, Guid> Reverse = new ConcurrentDictionary<string, Guid>();
+
+        public static void ClearAll()
+        {
+            Forward.Clear();
+            Reverse.Clear();
+        }
+
+        public static void TryAdd(IContentType contentType)
+        {
+            TryAdd(contentType.Key, contentType.Alias);
+        }
+
+        public static void TryAdd(Guid guid, string alias)
+        {
+            Forward.TryAdd(guid, alias);
+            Reverse.TryAdd(alias, guid);
+        }
+
+        public static bool TryGetAlias(Guid key, out string alias, IContentTypeService contentTypeService = null)
+        {
+            if (Forward.TryGetValue(key, out alias))
+                return true;
+
+            // The alias isn't cached, we can attempt to get it via the content-type service, using the GUID.
+            if (contentTypeService != null)
+            {
+                var contentType = contentTypeService.GetContentType(key);
+                if (contentType != null)
+                {
+                    TryAdd(contentType);
+                    alias = contentType.Alias;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool TryGetGuid(string alias, out Guid key, IContentTypeService contentTypeService = null)
+        {
+            if (Reverse.TryGetValue(alias, out key))
+                return true;
+
+            // The GUID isn't cached, we can attempt to get it via the content-type service, using the alias.
+            if (contentTypeService != null)
+            {
+                var contentType = contentTypeService.GetContentType(alias);
+                if (contentType != null)
+                {
+                    TryAdd(contentType);
+                    key = contentType.Key;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static void TryRemove(IContentType contentType)
+        {
+            if (TryRemove(contentType.Alias) == false)
+            {
+                TryRemove(contentType.Key);
+            }
+        }
+
+        public static bool TryRemove(Guid guid)
+        {
+            return Forward.TryRemove(guid, out string alias)
+                ? Reverse.TryRemove(alias, out guid)
+                : false;
+        }
+
+        public static bool TryRemove(string alias)
+        {
+            return Reverse.TryRemove(alias, out Guid guid)
+                ? Forward.TryRemove(guid, out alias)
+                : false;
+        }
+    }
+}

--- a/src/Our.Umbraco.InnerContent/Helpers/InnerContentHelper.cs
+++ b/src/Our.Umbraco.InnerContent/Helpers/InnerContentHelper.cs
@@ -125,7 +125,7 @@ namespace Our.Umbraco.InnerContent.Helpers
         {
             if (ContentTypeCacheHelper.TryGetGuid(contentTypeAlias, out Guid key, contentTypeService))
             {
-                item["icContentTypeGuid"] = key.ToString();
+                item[InnerContentConstants.ContentTypeGuidPropertyKey] = key.ToString();
             }
         }
 

--- a/src/Our.Umbraco.InnerContent/Helpers/InnerContentHelper.cs
+++ b/src/Our.Umbraco.InnerContent/Helpers/InnerContentHelper.cs
@@ -102,10 +102,15 @@ namespace Our.Umbraco.InnerContent.Helpers
 
         internal static IContentType GetContentTypeFromItem(JObject item)
         {
+            var contentTypeGuid = GetContentTypeGuidFromItem(item);
+            if (contentTypeGuid.HasValue && contentTypeGuid.Value != Guid.Empty)
+                return ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeGuid.Value);
+
             var contentTypeAlias = GetContentTypeAliasFromItem(item);
-            return !contentTypeAlias.IsNullOrWhiteSpace()
-                ? ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeAlias)
-                : null;
+            if (string.IsNullOrWhiteSpace(contentTypeAlias) == false)
+                return ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeAlias);
+
+            return null;
         }
 
         internal static PublishedContentType GetPublishedContentTypeFromItem(JObject item)

--- a/src/Our.Umbraco.InnerContent/Helpers/InnerContentHelper.cs
+++ b/src/Our.Umbraco.InnerContent/Helpers/InnerContentHelper.cs
@@ -7,6 +7,7 @@ using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Services;
 using Umbraco.Web;
 
 namespace Our.Umbraco.InnerContent.Helpers
@@ -102,15 +103,30 @@ namespace Our.Umbraco.InnerContent.Helpers
 
         internal static IContentType GetContentTypeFromItem(JObject item)
         {
+            var contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+
             var contentTypeGuid = GetContentTypeGuidFromItem(item);
             if (contentTypeGuid.HasValue && contentTypeGuid.Value != Guid.Empty)
-                return ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeGuid.Value);
+                return contentTypeService.GetContentType(contentTypeGuid.Value);
 
             var contentTypeAlias = GetContentTypeAliasFromItem(item);
             if (string.IsNullOrWhiteSpace(contentTypeAlias) == false)
-                return ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeAlias);
+            {
+                // Future-proofing - setting the GUID, queried from the alias
+                SetContentTypeGuid(item, contentTypeAlias, contentTypeService);
+
+                return contentTypeService.GetContentType(contentTypeAlias);
+            }
 
             return null;
+        }
+
+        internal static void SetContentTypeGuid(JObject item, string contentTypeAlias, IContentTypeService contentTypeService)
+        {
+            if (ContentTypeCacheHelper.TryGetGuid(contentTypeAlias, out Guid key, contentTypeService))
+            {
+                item["icContentTypeGuid"] = key.ToString();
+            }
         }
 
         internal static PublishedContentType GetPublishedContentTypeFromItem(JObject item)
@@ -119,16 +135,14 @@ namespace Our.Umbraco.InnerContent.Helpers
 
             // First we check if the item has a content-type GUID...
             var contentTypeGuid = GetContentTypeGuidFromItem(item);
-            if (contentTypeGuid != null && contentTypeGuid.HasValue && contentTypeGuid.Value != Guid.Empty)
+            if (contentTypeGuid.HasValue)
             {
                 // HACK: If Umbraco's `PublishedContentType.Get` method supported a GUID parameter,
                 // we could use that method directly, however it only supports the content-type alias (as of v7.4.0)
                 // See: https://github.com/umbraco/Umbraco-CMS/blob/release-7.4.0/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs#L133
                 // Our workaround is to cache a content-type GUID => alias lookup.
 
-                contentTypeAlias = ApplicationContext.Current.ApplicationCache.StaticCache.GetCacheItem<string>(
-                    string.Format(InnerContentConstants.ContentTypeAliasByGuidCacheKey, contentTypeGuid.Value),
-                    () => ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeGuid.Value).Alias);
+                ContentTypeCacheHelper.TryGetAlias(contentTypeGuid.Value, out contentTypeAlias, ApplicationContext.Current.Services.ContentTypeService);
             }
 
             // If we don't have the content-type alias at this point, check if we can get it from the item

--- a/src/Our.Umbraco.InnerContent/InnerContentConstants.cs
+++ b/src/Our.Umbraco.InnerContent/InnerContentConstants.cs
@@ -7,5 +7,7 @@
         internal const string ContentTypeGuidPropertyKey = "icContentTypeGuid";
 
         internal const string PreValuesCacheKey = "Our.Umbraco.InnerContent.GetPreValuesCollectionByDataTypeId_{0}";
+
+        internal const string ContentTypesPreValueKey = "contentTypes";
     }
 }

--- a/src/Our.Umbraco.InnerContent/InnerContentConstants.cs
+++ b/src/Our.Umbraco.InnerContent/InnerContentConstants.cs
@@ -7,7 +7,5 @@
         internal const string ContentTypeGuidPropertyKey = "icContentTypeGuid";
 
         internal const string PreValuesCacheKey = "Our.Umbraco.InnerContent.GetPreValuesCollectionByDataTypeId_{0}";
-
-        internal const string ContentTypeAliasByGuidCacheKey = "Our.Umbraco.InnerContent.GetContentTypeAliasByGuid_{0}";
     }
 }

--- a/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
+++ b/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
@@ -80,13 +80,18 @@
   <ItemGroup>
     <Compile Include="Bootstrap.cs" />
     <Compile Include="Converters\InnerContentValueConverter.cs" />
+    <Compile Include="Helpers\ContentTypeCacheHelper.cs" />
     <Compile Include="Helpers\InnerContentHelper.cs" />
     <Compile Include="InnerContentConstants.cs" />
     <Compile Include="Models\DetachedPublishedContent.cs" />
     <Compile Include="Models\DetachedPublishedProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
+    <Compile Include="PropertyEditors\InnerContentPreValueEditor.cs" />
+    <Compile Include="PropertyEditors\InnerContentPropertyEditor.cs" />
     <Compile Include="PropertyEditors\InnerContentPropertyValueEditorWrapper.cs" />
+    <Compile Include="PropertyEditors\SimpleInnerContentPropertyEditor.cs" />
+    <Compile Include="PropertyEditors\SimpleInnerContentPreValueEditor.cs" />
     <Compile Include="PropertyEditors\SimpleInnerContentPropertyValueEditor.cs" />
     <Compile Include="Web\Controllers\InnerContentApiController.cs" />
     <Compile Include="Web\WebApi\Filters\UseInternalActionFilterAttribute.cs" />

--- a/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
+++ b/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
@@ -88,7 +88,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyEditors\InnerContentPreValueEditor.cs" />
-    <Compile Include="PropertyEditors\InnerContentPropertyEditor.cs" />
     <Compile Include="PropertyEditors\InnerContentPropertyValueEditorWrapper.cs" />
     <Compile Include="PropertyEditors\SimpleInnerContentPropertyEditor.cs" />
     <Compile Include="PropertyEditors\SimpleInnerContentPreValueEditor.cs" />

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPreValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPreValueEditor.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json.Linq;
+using Our.Umbraco.InnerContent.Helpers;
+using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
+
+namespace Our.Umbraco.InnerContent.PropertyEditors
+{
+    public class InnerContentPreValueEditor : PreValueEditor
+    {
+        protected bool TryEnsureContentTypeGuids(JArray items)
+        {
+            if (items == null)
+                return false;
+
+            var ensured = false;
+
+            foreach (JObject item in items)
+            {
+                var contentTypeGuid = item[InnerContentConstants.ContentTypeGuidPropertyKey];
+                if (contentTypeGuid != null)
+                    continue;
+
+                var contentTypeAlias = item[InnerContentConstants.ContentTypeAliasPropertyKey];
+                if (contentTypeAlias == null)
+                    continue;
+
+                InnerContentHelper.SetContentTypeGuid(item, contentTypeAlias.Value<string>(), ApplicationContext.Current.Services.ContentTypeService);
+                ensured = true;
+            }
+
+            return ensured;
+        }
+    }
+}

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyEditor.cs
@@ -1,7 +1,0 @@
-﻿using Umbraco.Core.PropertyEditors;
-
-namespace Our.Umbraco.InnerContent.PropertyEditors
-{
-    public abstract class InnerContentPropertyEditor : PropertyEditor
-    { }
-}

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyEditor.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Core.PropertyEditors;
+
+namespace Our.Umbraco.InnerContent.PropertyEditors
+{
+    public abstract class InnerContentPropertyEditor : PropertyEditor
+    { }
+}

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyValueEditorWrapper.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyValueEditorWrapper.cs
@@ -239,6 +239,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                 || propKey == "children"
                 || propKey == "key"
                 || propKey == "icon"
+                || propKey == InnerContentConstants.ContentTypeGuidPropertyKey
                 || propKey == InnerContentConstants.ContentTypeAliasPropertyKey;
         }
 

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using Our.Umbraco.InnerContent.Helpers;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors;
+
+namespace Our.Umbraco.InnerContent.PropertyEditors
+{
+    public class SimpleInnerContentPreValueEditor : InnerContentPreValueEditor
+    {
+        [PreValueField("contentTypes", "Content Types", "~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html", Description = "Select the content types to use as the data blueprint.")]
+        public string[] ContentTypes { get; set; }
+
+        [PreValueField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed in this stack.")]
+        public string MaxItems { get; set; }
+
+        [PreValueField("singleItemMode", "Single Item Mode", "boolean", Description = "Set whether to work in single item mode (only the first defined Content Type will be used).")]
+        public string SingleItemMode { get; set; }
+
+        [PreValueField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
+        public string HideLabel { get; set; }
+
+        [PreValueField("disablePreview", "Disable Preview", "boolean", Description = "Set whether to disable the preview of the items in the stack.")]
+        public string DisablePreview { get; set; }
+
+        public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
+        {
+            if (persistedPreVals.IsDictionaryBased)
+            {
+                var dict = persistedPreVals.PreValuesAsDictionary;
+                if (dict.TryGetValue("contentTypes", out PreValue contentTypes) && string.IsNullOrWhiteSpace(contentTypes.Value) == false)
+                {
+                    var items = JArray.Parse(contentTypes.Value);
+                    if (TryEnsureContentTypeGuids(items))
+                    {
+                        contentTypes.Value = items.ToString();
+                    }
+                }
+            }
+
+            return base.ConvertDbToEditor(defaultPreVals, persistedPreVals);
+        }
+    }
+}

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
+using Umbraco.Core.IO;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 
@@ -7,8 +8,18 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
 {
     public class SimpleInnerContentPreValueEditor : InnerContentPreValueEditor
     {
-        [PreValueField("contentTypes", "Content Types", "~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html", Description = "Select the content types to use as the data blueprint.")]
-        public string[] ContentTypes { get; set; }
+        public SimpleInnerContentPreValueEditor()
+            : base()
+        {
+            // This ensures that the "contentTypes" field is always at the top of the prevalue fields.
+            Fields.Insert(0, new PreValueField
+            {
+                Key = InnerContentConstants.ContentTypesPreValueKey,
+                Name = "Content Types",
+                View = IOHelper.ResolveUrl("~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html"),
+                Description = "Select the content types to use as the data blueprint."
+            });
+        }
 
         public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
         {

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
@@ -15,7 +15,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
             if (persistedPreVals.IsDictionaryBased)
             {
                 var dict = persistedPreVals.PreValuesAsDictionary;
-                if (dict.TryGetValue("contentTypes", out PreValue contentTypes) && string.IsNullOrWhiteSpace(contentTypes.Value) == false)
+                if (dict.TryGetValue(InnerContentConstants.ContentTypesPreValueKey, out PreValue contentTypes) && string.IsNullOrWhiteSpace(contentTypes.Value) == false)
                 {
                     var items = JArray.Parse(contentTypes.Value);
                     if (TryEnsureContentTypeGuids(items))

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPreValueEditor.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
-using Our.Umbraco.InnerContent.Helpers;
-using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 
@@ -11,18 +9,6 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
     {
         [PreValueField("contentTypes", "Content Types", "~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html", Description = "Select the content types to use as the data blueprint.")]
         public string[] ContentTypes { get; set; }
-
-        [PreValueField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed in this stack.")]
-        public string MaxItems { get; set; }
-
-        [PreValueField("singleItemMode", "Single Item Mode", "boolean", Description = "Set whether to work in single item mode (only the first defined Content Type will be used).")]
-        public string SingleItemMode { get; set; }
-
-        [PreValueField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
-        public string HideLabel { get; set; }
-
-        [PreValueField("disablePreview", "Disable Preview", "boolean", Description = "Set whether to disable the preview of the items in the stack.")]
-        public string DisablePreview { get; set; }
 
         public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
         {

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyEditor.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Our.Umbraco.InnerContent.PropertyEditors
 {
-    public abstract class SimpleInnerContentPropertyEditor : InnerContentPropertyEditor
+    public abstract class SimpleInnerContentPropertyEditor : PropertyEditor
     {
         private IDictionary<string, object> defaultPreValues;
         public override IDictionary<string, object> DefaultPreValues
@@ -17,10 +17,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
         {
             this.defaultPreValues = new Dictionary<string, object>
             {
-                { "contentTypes", "" },
-                { "maxItems", 0 },
-                { "singleItemMode", "0" },
-                { "disablePreview", "0" }
+                { "contentTypes", string.Empty }
             };
         }
 

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyEditor.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
+
+namespace Our.Umbraco.InnerContent.PropertyEditors
+{
+    public abstract class SimpleInnerContentPropertyEditor : InnerContentPropertyEditor
+    {
+        private IDictionary<string, object> defaultPreValues;
+        public override IDictionary<string, object> DefaultPreValues
+        {
+            get { return this.defaultPreValues; }
+            set { this.defaultPreValues = value; }
+        }
+
+        public SimpleInnerContentPropertyEditor()
+            : base()
+        {
+            this.defaultPreValues = new Dictionary<string, object>
+            {
+                { "contentTypes", "" },
+                { "maxItems", 0 },
+                { "singleItemMode", "0" },
+                { "disablePreview", "0" }
+            };
+        }
+
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new SimpleInnerContentPreValueEditor();
+        }
+
+        protected override PropertyValueEditor CreateValueEditor()
+        {
+            return new SimpleInnerContentPropertyValueEditor(base.CreateValueEditor());
+        }
+    }
+}

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyEditor.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
         {
             this.defaultPreValues = new Dictionary<string, object>
             {
-                { "contentTypes", string.Empty }
+                { InnerContentConstants.ContentTypesPreValueKey, string.Empty }
             };
         }
 

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
@@ -50,7 +50,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
 
             if (token is JObject jObj)
             {
-                if (jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
+                if (jObj[InnerContentConstants.ContentTypeGuidPropertyKey] != null || jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
                 {
                     ConvertInnerContentDbToString(jObj, dataTypeService);
                 }
@@ -103,7 +103,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
 
             if (token is JObject jObj)
             {
-                if (jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
+                if (jObj[InnerContentConstants.ContentTypeGuidPropertyKey] != null || jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
                 {
                     ConvertInnerContentDbToEditor(jObj, dataTypeService);
                 }
@@ -149,7 +149,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
 
             if (token is JObject jObj)
             {
-                if (jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
+                if (jObj[InnerContentConstants.ContentTypeGuidPropertyKey] != null || jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
                 {
                     ConvertInnerContentEditorToDb(jObj, ApplicationContext.Current.Services.DataTypeService);
                 }

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -37,11 +37,6 @@ angular.module("umbraco").controller("Our.Umbraco.InnerContent.Controllers.DocTy
 
         innerContentService.getAllContentTypes().then(function (docTypes) {
             $scope.model.docTypes = docTypes;
-
-            // Sometimes changes in Inner Content require
-            // the stored config models to be updated so we 
-            // pass the models through to be pre processed
-            innerContentService.preProcessModels(undefined, $scope.model.value, docTypes);
         });
 
         if (!$scope.model.value) {
@@ -77,12 +72,6 @@ angular.module("umbraco").controller("Our.Umbraco.InnerContent.Controllers.DocTy
 
         innerContentService.getAllContentTypes().then(function (docTypes) {
             $scope.model.docTypes = docTypes;
-
-            // Sometimes changes in Inner Content require
-            // the stored config models to be updated so we 
-            // pass the models through to be pre processed
-            innerContentService.preProcessModels(undefined, $scope.model.value, docTypes);
-
         });
 
         if (!$scope.model.value) {
@@ -492,92 +481,6 @@ angular.module("umbraco").factory('innerContentService', [
             return self.createEditorModel(contentType).then(function (editorModel) {
                 return self.createDbModel(editorModel);
             });
-        }
-
-        self.preProcessModels = function (dbModels, configContentTypes, docTypes) {
-
-            var contentTypeAliases = [];
-
-            // Pre v1.0.4 we stored the doc type alias
-            // but as of 1.0.4 we switched to using the guid
-            // so we remap any models which store the alias
-            // to now use the guid instead
-
-            var fixDbModels = false;
-
-            if (dbModels) {
-                _.forEach(dbModels, function (m) {
-                    if (m.hasOwnProperty("icContentTypeAlias")) {
-                        contentTypeAliases.push(m.icContentTypeAlias);
-                        fixDbModels = true;
-                        return true;
-                    }
-                    return false;
-                });
-            }
-
-            var doFixDbModels = function (dbModels, docTypes) {
-                _.forEach(dbModels, function (itm) {
-                    if (itm.hasOwnProperty("icContentTypeAlias")) {
-                        var dt = _.find(docTypes, function (itm2) {
-                            return itm2.alias.toLowerCase() === itm.icContentTypeAlias.toLowerCase();
-                        });
-                        itm.icContentTypeGuid = dt.guid;
-                        delete itm.icContentTypeAlias;
-                    }
-                });
-            }
-
-            var fixConfigContentTypes = false;
-
-            if (configContentTypes) {
-                _.forEach(configContentTypes, function (ct) {
-                    if (ct.hasOwnProperty("icContentTypeAlias")) {
-                        contentTypeAliases.push(ct.icContentTypeAlias);
-                        fixConfigContentTypes = true;
-                        return true;
-                    }
-                    return false;
-                });
-            }
-
-            var doFixConfigContentTypes = function (contentTypes, docTypes) {
-                _.forEach(contentTypes, function (itm) {
-                    if (itm.hasOwnProperty("icContentTypeAlias")) {
-                        var dt = _.find(docTypes, function (itm2) {
-                            return itm2.alias.toLowerCase() === itm.icContentTypeAlias.toLowerCase();
-                        });
-                        itm.icContentTypeGuid = dt.guid;
-                        delete itm.icContentTypeAlias;
-                    }
-                });
-            }
-
-            contentTypeAliases = _.uniq(contentTypeAliases);
-
-            if (fixDbModels || fixConfigContentTypes) {
-                if (docTypes) {
-                    if (fixDbModels) {
-                        doFixDbModels(dbModels, docTypes);
-                    }
-                    if (fixConfigContentTypes) {
-                        doFixConfigContentTypes(configContentTypes, docTypes);
-                    }
-                } else {
-                    // If we don't have a list of content types, go get them
-                    // but only get ones we know we need to fix
-                    icResources.getContentTypesByAlias(contentTypeAliases).then(function (docTypes2) {
-                        if (fixDbModels) {
-                            doFixDbModels(dbModels, docTypes2);
-                        }
-                        if (fixConfigContentTypes) {
-                            doFixConfigContentTypes(configContentTypes, docTypes2);
-                        }
-                    });
-                }
-
-            }
-
         }
 
         self.compareCurrentUmbracoVersion = function compareCurrentUmbracoVersion(v, options) {


### PR DESCRIPTION
Adds support for checking the ContentType GUID first, then checking ContentType alias as a fallback.

Cross-referencing with a PR for StackedContent, https://github.com/umco/umbraco-stacked-content/pull/32

---

This is intended as an alternative solution to PRs #12 and #13 ... _Third time's a charm!_ ☘️ 