### PR TITLE
"Insert Content" overlay modal improvements

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -143,7 +143,7 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
 
             scope.contentTypePickerOverlay = {
                 view: "itempicker",
-                filter: false,
+                filter: true,
                 title: "Insert Content",
                 show: false,
                 submit: function (model) {

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.overlay.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.overlay.html
@@ -3,7 +3,7 @@
     <umb-overlay ng-if="contentTypePickerOverlay.show"
                  model="contentTypePickerOverlay"
                  view="contentTypePickerOverlay.view"
-                 position="target">
+                 position="center">
     </umb-overlay>
 
     <umb-overlay ng-if="contentEditorOverlay.show"


### PR DESCRIPTION
Adds filter textbox to the "Insert Content" modal and sets the overlay to `position="center"`.

My reason for this is when you have more than (say 6) the "position=target" overlay feels crowded and difficult to find a content-type.  When set to "position=center" the modal is larger (easily displays 9 items) and with the filter enabled it looks friendlier.

Maybe this could be a prevalue config option? e.g. Picker = small or large?
or could be dynamic, e.g. when there are over 6 content-types available, it auto switches from small to large?

Any thoughts?

---
This PR is initially intended for discussion.  It's totally open to community feedback.