### PR TITLE
Adds support for Content Templates (aka Blueprints)

### DIFF
--- a/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
+++ b/src/Our.Umbraco.InnerContent/Our.Umbraco.InnerContent.csproj
@@ -92,6 +92,7 @@
     <Content Include="Web\UI\App_Plugins\InnerContent\css\innercontent.css" />
     <Content Include="Web\UI\App_Plugins\InnerContent\js\innercontent.controllers.js" />
     <Content Include="Web\UI\App_Plugins\InnerContent\js\innercontent.resources.js" />
+    <Content Include="Web\UI\App_Plugins\InnerContent\views\innercontent.create.html" />
     <Content Include="Web\UI\App_Plugins\InnerContent\views\innercontent.dialog.html" />
     <Content Include="Web\UI\App_Plugins\InnerContent\views\innercontent.unsavedchanges.html" />
     <Content Include="Web\UI\App_Plugins\InnerContent\views\innercontent.overlay.html" />

--- a/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
+++ b/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
@@ -38,13 +38,16 @@ namespace Our.Umbraco.InnerContent.Web.Controllers
             // NOTE: Using an anonymous class, as the `ContentTypeBasic` type is heavier than what we need (for our requirements)
             return contentTypes.Select(ct => new
             {
-                name = ct.Name, // TODO: localize the name (in case of dictionary items), e.g. `localizedTextService.UmbracoDictionaryTranslate`
-                description = ct.Description, // TODO: localize the description (in case of dictionary items), e.g. `localizedTextService.UmbracoDictionaryTranslate`
+                // TODO: localize the name and description (in case of dictionary items)
+                // Umbraco core uses `localizedTextService.UmbracoDictionaryTranslate`, but this is currently marked as internal.
+                // https://github.com/umbraco/Umbraco-CMS/blob/release-7.7.0/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs#L76
+
+                name = ct.Name,
+                description = ct.Description,
                 guid = ct.Key,
                 key = ct.Key,
                 icon = string.IsNullOrWhiteSpace(ct.Icon) || ct.Icon == ".sprTreeFolder" ? "icon-document" : ct.Icon,
                 blueprints = blueprints.Where(bp => bp.ContentTypeId == ct.Id).ToDictionary(bp => bp.Id, bp => bp.Name)
-                // TODO: tabs = ct.CompositionPropertyGroups.Select(y => y.Name).Distinct()
             });
         }
 

--- a/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
+++ b/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
@@ -76,17 +76,17 @@ namespace Our.Umbraco.InnerContent.Web.Controllers
 
         [HttpGet]
         [UseInternalActionFilter("Umbraco.Web.WebApi.Filters.OutgoingEditorModelEventAttribute", onActionExecuted: true)]
-        public ContentItemDisplay GetContentTypeScaffoldByGuid(Guid contentTypeGuid, int blueprintId = 0)
+        public ContentItemDisplay GetContentTypeScaffoldByGuid(Guid guid)
         {
-            var controller = new ContentController();
+            var contentType = Services.ContentTypeService.GetContentType(guid);
+            return new ContentController().GetEmpty(contentType.Alias, -20);
+        }
 
-            if (blueprintId > 0)
-            {
-                return controller.GetEmpty(blueprintId, -20);
-            }
-
-            var contentType = Services.ContentTypeService.GetContentType(contentTypeGuid);
-            return controller.GetEmpty(contentType.Alias, -20);
+        [HttpGet]
+        [UseInternalActionFilter("Umbraco.Web.WebApi.Filters.OutgoingEditorModelEventAttribute", onActionExecuted: true)]
+        public ContentItemDisplay GetContentTypeScaffoldByBlueprintId(int blueprintId)
+        {
+            return new ContentController().GetEmpty(blueprintId, -20);
         }
     }
 }

--- a/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
+++ b/src/Our.Umbraco.InnerContent/Web/Controllers/InnerContentApiController.cs
@@ -40,6 +40,7 @@ namespace Our.Umbraco.InnerContent.Web.Controllers
             {
                 name = ct.Name, // TODO: localize the name (in case of dictionary items), e.g. `localizedTextService.UmbracoDictionaryTranslate`
                 description = ct.Description, // TODO: localize the description (in case of dictionary items), e.g. `localizedTextService.UmbracoDictionaryTranslate`
+                guid = ct.Key,
                 key = ct.Key,
                 icon = string.IsNullOrWhiteSpace(ct.Icon) || ct.Icon == ".sprTreeFolder" ? "icon-document" : ct.Icon,
                 blueprints = blueprints.Where(bp => bp.ContentTypeId == ct.Id).ToDictionary(bp => bp.Id, bp => bp.Name)

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/css/innercontent.css
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/css/innercontent.css
@@ -31,3 +31,7 @@
 .inner-content-dialog > .nav-tabs {
     margin: -31px 0 0 20px;
 }
+
+.inner-content-pane {
+    margin: 30px 20px;
+}

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -176,7 +176,7 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
             // Helper function to createEditorModel but at the same time
             // cache the scaffold so that if we create another item of the same
             // content type, we don't need to fetch the scaffold again
-            var createEditorModel = function (contentType, blueprintId, dbModel) {
+            var createEditorModel = function (contentType, dbModel, blueprintId) {
 
                 var process = function (editorModel, dbModel2) {
                     var n = angular.copy(editorModel);
@@ -189,7 +189,7 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
                     var res = process(scope.config.editorModels[cacheKey], dbModel);
                     return $q.when(res);
                 } else {
-                    return innerContentService.createEditorModel(contentType, blueprintId).then(function (em) {
+                    return innerContentService.createEditorModel(contentType, dbModel, blueprintId).then(function (em) {
                         scope.config.editorModels[cacheKey] = em;
                         var res = process(scope.config.editorModels[cacheKey], dbModel);
                         return res;
@@ -206,7 +206,7 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
                 submit: function (model) {
                     var ct = getContentType(model.selectedItem.key);
                     var bp = model.selectedItem.blueprint;
-                    createEditorModel(ct, bp).then(function (em) {
+                    createEditorModel(ct, null, bp).then(function (em) {
                         scope.currentItem = em;
                         scope.closeContentTypePickerOverlay();
                         scope.openContentEditorOverlay();
@@ -244,7 +244,7 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
 
                 if (scope.contentTypePickerOverlay.availableItems.length === 1 && _.isEmpty(scope.contentTypePickerOverlay.availableItems[0].blueprints)) {
                     var ct = getContentType(scope.contentTypePickerOverlay.availableItems[0].key);
-                    createEditorModel(ct, -1).then(function (em) {
+                    createEditorModel(ct).then(function (em) {
                         scope.currentItem = em;
                         scope.openContentEditorOverlay();
                     });
@@ -285,7 +285,7 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
                     scope.openContentTypePickerOverlay();
                 } else {
                     var ct = getContentType(scope.config.data.model.icContentTypeGuid);
-                    createEditorModel(ct, -1, scope.config.data.model).then(function (em) {
+                    createEditorModel(ct, scope.config.data.model).then(function (em) {
                         scope.currentItem = em;
                         scope.openContentEditorOverlay();
                     });
@@ -480,7 +480,7 @@ angular.module("umbraco").factory('innerContentService', [
             return icResources.getContentTypeIconsByGuid(guids);
         }
 
-        self.createEditorModel = function (contentType, blueprintId, dbModel) {
+        self.createEditorModel = function (contentType, dbModel, blueprintId) {
 
             return getScaffold(contentType, blueprintId).then(function (scaffold) {
 
@@ -542,7 +542,7 @@ angular.module("umbraco").factory('innerContentService', [
         }
 
         self.createDefaultDbModel = function (contentType) {
-            return self.createEditorModel(contentType, -1).then(function (editorModel) {
+            return self.createEditorModel(contentType).then(function (editorModel) {
                 return self.createDbModel(editorModel);
             });
         }

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -302,10 +302,10 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
                     var guids = scope.config.contentTypes.map(function (itm) {
                         return itm.icContentTypeGuid;
                     });
-                    innerContentService.getContentTypesByGuid(guids).then(function (docTypes) {
+                    innerContentService.getContentTypesByGuid(guids).then(function (contentTypes) {
 
                         // Cache items in the PE's config so we only request these once per PE instance
-                        scope.config.contentTypePickerItems = docTypes;
+                        scope.config.contentTypePickerItems = contentTypes;
 
                         initOpen();
 

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -408,7 +408,8 @@ angular.module("umbraco").factory('innerContentService', [
         var self = {};
 
         var getScaffold = function (contentType, blueprintId) {
-            return icResources.getContentTypeScaffoldByGuid(contentType.icContentTypeGuid, blueprintId).then(function (scaffold) {
+
+            var processScaffold = function (scaffold) {
 
                 // remove all tabs except the specified tab
                 if (contentType.hasOwnProperty("icTabAlias")) {
@@ -432,7 +433,13 @@ angular.module("umbraco").factory('innerContentService', [
 
                 return scaffold;
 
-            });
+            };
+
+            if (blueprintId > 0) {
+                return icResources.getContentTypeScaffoldByBlueprintId(blueprintId).then(processScaffold);
+            } else {
+                return icResources.getContentTypeScaffoldByGuid(contentType.icContentTypeGuid).then(processScaffold);
+            }
         }
 
         self.populateName = function (itm, idx, contentTypes) {

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -409,7 +409,7 @@ angular.module("umbraco").factory('innerContentService', [
 
         var getScaffold = function (contentType, blueprintId) {
 
-            var processScaffold = function (scaffold) {
+            var process = function (scaffold) {
 
                 // remove all tabs except the specified tab
                 if (contentType.hasOwnProperty("icTabAlias")) {
@@ -436,9 +436,9 @@ angular.module("umbraco").factory('innerContentService', [
             };
 
             if (blueprintId > 0) {
-                return icResources.getContentTypeScaffoldByBlueprintId(blueprintId).then(processScaffold);
+                return icResources.getContentTypeScaffoldByBlueprintId(blueprintId).then(process);
             } else {
-                return icResources.getContentTypeScaffoldByGuid(contentType.icContentTypeGuid).then(processScaffold);
+                return icResources.getContentTypeScaffoldByGuid(contentType.icContentTypeGuid).then(process);
             }
         }
 

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -167,9 +167,9 @@ angular.module('umbraco.directives').directive('innerContentOverlay', [
             scope.config.editorModels = scope.config.editorModels || {};
             scope.currentItem = null;
 
-            var getContentType = function (key) {
+            var getContentType = function (guid) {
                 return _.find(scope.config.contentTypes, function (ct) {
-                    return ct.icContentTypeGuid.toLowerCase() === key.toLowerCase();
+                    return ct.icContentTypeGuid.toLowerCase() === guid.toLowerCase();
                 });
             }
 

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.resources.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.resources.js
@@ -40,14 +40,24 @@
                     'Failed to retrieve content type icons'
                 );
             },
-            getContentTypeScaffoldByGuid: function (contentTypeGuid, blueprintId) {
+            getContentTypeScaffoldByGuid: function (guid) {
                 return umbRequestHelper.resourcePromise(
                     $http({
                         url: "/umbraco/backoffice/InnerContent/InnerContentApi/GetContentTypeScaffoldByGuid",
                         method: "GET",
-                        params: { contentTypeGuid: contentTypeGuid, blueprintId: blueprintId }
+                        params: { guid: guid }
                     }),
-                    'Failed to retrieve content type scaffold'
+                    'Failed to retrieve content type scaffold by Guid'
+                );
+            },
+            getContentTypeScaffoldByBlueprintId: function (blueprintId) {
+                return umbRequestHelper.resourcePromise(
+                    $http({
+                        url: "/umbraco/backoffice/InnerContent/InnerContentApi/GetContentTypeScaffoldByBlueprintId",
+                        method: "GET",
+                        params: { blueprintId: blueprintId }
+                    }),
+                    'Failed to retrieve content type scaffold by blueprint Id'
                 );
             }
         };

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.resources.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.resources.js
@@ -40,12 +40,12 @@
                     'Failed to retrieve content type icons'
                 );
             },
-            getContentTypeScaffoldByGuid: function (guid) {
+            getContentTypeScaffoldByGuid: function (contentTypeGuid, blueprintId) {
                 return umbRequestHelper.resourcePromise(
                     $http({
                         url: "/umbraco/backoffice/InnerContent/InnerContentApi/GetContentTypeScaffoldByGuid",
                         method: "GET",
-                        params: { guid: guid }
+                        params: { contentTypeGuid: contentTypeGuid, blueprintId: blueprintId }
                     }),
                     'Failed to retrieve content type scaffold'
                 );

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.create.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.create.html
@@ -1,0 +1,48 @@
+﻿<div class="inner-content-pane" ng-controller="Our.Umbraco.InnerContent.Controllers.InnerContentCreateController" ng-cloak>
+
+    <h5 ng-show="selectContentType">Select a content type</h5>
+    <h5 ng-show="selectBlueprint"><localize key="blueprints_selectBlueprint">Select a blueprint</localize></h5>
+
+    <p class="abstract" ng-if="allowedTypes && allowedTypes.length === 0">
+        <localize key="create_noDocumentTypes" />
+    </p>
+
+    <ul class="umb-actions umb-actions-child" ng-show="selectContentType">
+        
+        <li data-element="action-create-{{docType.alias}}" ng-repeat="docType in allowedTypes | orderBy:'name':false">
+            <a ng-click="createOrSelectBlueprintIfAny(docType)">
+                <i class="large {{docType.icon}}"></i>
+                <span class="menu-label">
+                    {{docType.name}}
+                    <small>
+                        {{docType.description}}
+                    </small>
+                </span>
+            </a>
+        </li>
+
+    </ul>
+
+    <ul class="umb-actions umb-actions-child" ng-show="selectBlueprint">
+
+        <li ng-repeat="(key, value) in selectedDocType.blueprints | orderBy:'name':false">
+            <a ng-click="createFromBlueprint(selectedDocType.key, key)">
+                <i class="large {{selectedDocType.icon}}"></i>
+                <span class="menu-label">
+                    {{value}}
+                </span>
+            </a>
+        </li>
+
+        <li class="sep" ng-show="allowBlank">
+            <a ng-click="createBlank(selectedDocType.key)">
+                <i class="large {{selectedDocType.icon}}"></i>
+                <span class="menu-label">
+                    <localize key="blueprints_blankBlueprint">Blank</localize>
+                </span>
+            </a>
+        </li>
+
+    </ul>
+
+</div>

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.overlay.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.overlay.html
@@ -3,7 +3,7 @@
     <umb-overlay ng-if="contentTypePickerOverlay.show"
                  model="contentTypePickerOverlay"
                  view="contentTypePickerOverlay.view"
-                 position="target">
+                 position="right">
     </umb-overlay>
 
     <umb-overlay ng-if="contentEditorOverlay.show"


### PR DESCRIPTION
Reworks how the Content Type picker overlay works.

Targets the overlay to the "right" panel and enables Content Type selection to follow the same pattern as creating regular content nodes.

When a Content Type is selected, any Content Templates (Blueprints) will be displayed and can be selected.

Underlying updates have been made to the InnerContent resource & service scripts - these may be breaking changes, though I have only tested using Stacked Content, which (at present) has no side effects.