### PR TITLE
PropertyValueEditor - return converted value, not update reference value

### DIFF
--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
@@ -81,11 +81,8 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
             // Process value
             ConvertDbToEditorRecursive(value, dataTypeService);
 
-            // Update the value on the property
-            property.Value = JsonConvert.SerializeObject(value);
-
-            // Pass the call down
-            return base.ConvertDbToEditor(property, propertyType, dataTypeService);
+            // Return the JObject, Angular can handle it directly
+            return value;
         }
 
         protected void ConvertDbToEditorRecursive(JToken token, IDataTypeService dataTypeService)

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
@@ -29,7 +29,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                 return string.Empty;
 
             // Process value
-            ConvertDbToStringRecursive(value, property, propertyType, dataTypeService);
+            ConvertDbToStringRecursive(value, dataTypeService);
 
             // Update the value on the property
             property.Value = JsonConvert.SerializeObject(value);
@@ -38,13 +38,13 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
             return base.ConvertDbToString(property, propertyType, dataTypeService);
         }
 
-        protected void ConvertDbToStringRecursive(JToken token, Property property, PropertyType propertyType, IDataTypeService dataTypeService)
+        protected void ConvertDbToStringRecursive(JToken token, IDataTypeService dataTypeService)
         {
             if (token is JArray jArr)
             {
                 foreach (var item in jArr)
                 {
-                    ConvertDbToStringRecursive(item, property, propertyType, dataTypeService);
+                    ConvertDbToStringRecursive(item, dataTypeService);
                 }
             }
 
@@ -60,7 +60,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                     {
                         if (kvp.Value is JArray || kvp.Value is JObject)
                         {
-                            ConvertDbToStringRecursive(kvp.Value, property, propertyType, dataTypeService);
+                            ConvertDbToStringRecursive(kvp.Value, dataTypeService);
                         }
                     }
                 }
@@ -82,7 +82,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                 return string.Empty;
 
             // Process value
-            ConvertDbToEditorRecursive(value, property, propertyType, dataTypeService);
+            ConvertDbToEditorRecursive(value, dataTypeService);
 
             // Update the value on the property
             property.Value = JsonConvert.SerializeObject(value);
@@ -91,13 +91,13 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
             return base.ConvertDbToEditor(property, propertyType, dataTypeService);
         }
 
-        protected void ConvertDbToEditorRecursive(JToken token, Property property, PropertyType propertyType, IDataTypeService dataTypeService)
+        protected void ConvertDbToEditorRecursive(JToken token, IDataTypeService dataTypeService)
         {
             if (token is JArray jArr)
             {
                 foreach (var item in jArr)
                 {
-                    ConvertDbToEditorRecursive(item, property, propertyType, dataTypeService);
+                    ConvertDbToEditorRecursive(item, dataTypeService);
                 }
             }
 
@@ -113,7 +113,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                     {
                         if (kvp.Value is JArray || kvp.Value is JObject)
                         {
-                            ConvertDbToEditorRecursive(kvp.Value, property, propertyType, dataTypeService);
+                            ConvertDbToEditorRecursive(kvp.Value, dataTypeService);
                         }
                     }
                 }
@@ -131,19 +131,19 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                 return null;
 
             // Process value
-            ConvertEditorToDbRecursive(value, editorValue, currentValue);
+            ConvertEditorToDbRecursive(value, currentValue);
 
             // Return value
             return JsonConvert.SerializeObject(value);
         }
 
-        protected void ConvertEditorToDbRecursive(JToken token, ContentPropertyData editorValue, object currentValue)
+        protected void ConvertEditorToDbRecursive(JToken token, object currentValue)
         {
             if (token is JArray jArr)
             {
                 foreach (var item in jArr)
                 {
-                    ConvertEditorToDbRecursive(item, editorValue, currentValue);
+                    ConvertEditorToDbRecursive(item, currentValue);
                 }
             }
 
@@ -159,7 +159,7 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                     {
                         if (kvp.Value is JArray || kvp.Value is JObject)
                         {
-                            ConvertEditorToDbRecursive(kvp.Value, editorValue, currentValue);
+                            ConvertEditorToDbRecursive(kvp.Value, currentValue);
                         }
                     }
                 }

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
@@ -31,11 +31,8 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
             // Process value
             ConvertDbToStringRecursive(value, dataTypeService);
 
-            // Update the value on the property
-            property.Value = JsonConvert.SerializeObject(value);
-
-            // Pass the call down
-            return base.ConvertDbToString(property, propertyType, dataTypeService);
+            // Return the serialized value
+            return JsonConvert.SerializeObject(value);
         }
 
         protected void ConvertDbToStringRecursive(JToken token, IDataTypeService dataTypeService)

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
@@ -117,12 +117,16 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
         public override object ConvertEditorToDb(ContentPropertyData editorValue, object currentValue)
         {
             // Convert / validate value
-            if (editorValue.Value == null || string.IsNullOrWhiteSpace(editorValue.Value.ToString()))
-                return null;
+            if (editorValue.Value == null)
+                return string.Empty;
 
-            var value = JsonConvert.DeserializeObject<JToken>(editorValue.Value.ToString());
+            var dbValue = editorValue.Value.ToString();
+            if (string.IsNullOrWhiteSpace(dbValue))
+                return string.Empty;
+
+            var value = JsonConvert.DeserializeObject<JToken>(dbValue);
             if (value == null || (value is JArray && ((JArray)value).Count == 0))
-                return null;
+                return string.Empty;
 
             // Process value
             ConvertEditorToDbRecursive(value, currentValue);


### PR DESCRIPTION
While investigating https://github.com/umco/umbraco-stacked-content/issues/17, I found that we had been updating the `property.Value` reference, rather than returning the converted value.

I think the reason we did this was so that we could make a call to the base method to prepare the value correctly for the appropriate target - e.g. the database, editor, XML cache.

However investigating Umbraco core, it turns out that we don't need to do this - since InnerContent is dealing with `string` values, those base methods are ultimately calling `.ToString()`, (or in the case of the editor one, deserializing the JSON string that we've just serialized).

I've refactored the "ConvertDbTo" methods and tested locally, all working as expected - including the prevalue-based Dropdown list property-editor!

I've left more comments in the individual commits if you want to know more.