### PR TITLE
Adds a unique suffix to the tab ID

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -141,16 +141,19 @@ angular.module("umbraco").controller("Our.Umbraco.InnerContent.Controllers.Inner
 angular.module("umbraco").controller("Our.Umbraco.InnerContent.Controllers.InnerContentDialogController",
     [
         "$scope",
-        "$rootScope",
-        "$interpolate",
+        "overlayHelper",
 
-        function ($scope, $rootScope) {
+        function ($scope, overlayHelper) {
             $scope.item = $scope.model.dialogData.item;
 
             // Set a nodeContext property as nested property editors
             // can use this to know what doc type this node is etc
             // NC + DTGE do the same
             $scope.nodeContext = $scope.item;
+
+            // When using doctype compositions, the tab Id may conflict with any nested inner-content items.
+            // This attempts to make the tab ID to be unique.
+            $scope.tabIdSuffix = "_" + $scope.item.contentTypeAlias + "_" + overlayHelper.getNumberOfOverlays();
         }
     ]);
 

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.dialog.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.dialog.html
@@ -1,10 +1,10 @@
 ﻿<div class="inner-content-dialog" ng-controller="Our.Umbraco.InnerContent.Controllers.InnerContentDialogController">
 
-    <umb-tabs-nav ng-if="item.tabs" model="item.tabs"></umb-tabs-nav>
+    <umb-tabs-nav ng-if="item.tabs" model="item.tabs" id-suffix="{{tabIdSuffix}}"></umb-tabs-nav>
 
     <div class="umb-overlay-container">
         <umb-tabs-content class="form-horizontal" view="true">
-            <umb-tab id="tab{{tab.id}}" ng-repeat="tab in item.tabs" rel="{{tab.id}}">
+            <umb-tab id="tab{{tab.id}}{{tabIdSuffix}}" ng-repeat="tab in item.tabs" rel="{{tab.id}}">
 
                 <umb-property ng-repeat="property in tab.properties" property="property">
                     <umb-property-editor model="property"></umb-property-editor>


### PR DESCRIPTION
When using doctype compositions, the tab Id may conflict with any nested inner-content items.
This patch attempts to make the tab ID to be unique.

See https://github.com/umco/umbraco-stacked-content/issues/23 for further background on this issue.

---

I've targeted our upcoming IC v2 release, as the `id-suffix` parameter was introduced in Umbraco v7.6.0, https://github.com/umbraco/Umbraco-CMS/commit/bbe68cc22436917df70de0549045e45051888cfc#diff-9955a628133fc9728487ac47a164e611R47
(as opposed to IC v1 targets Umbraco v7.4.0)