### PR TITLE
Adds Copy/Paste API

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.controllers.js
@@ -400,10 +400,10 @@ angular.module("umbraco").factory('innerContentService', [
     "$q",
     "$interpolate",
     "contentResource",
-
+    "localStorageService",
     "Our.Umbraco.InnerContent.Resources.InnerContentResources",
 
-    function ($q, $interpolate, contentResource, icResources) {
+    function ($q, $interpolate, contentResource, localStorageService, icResources) {
 
         var self = {};
 
@@ -600,6 +600,34 @@ angular.module("umbraco").factory('innerContentService', [
 
             return 0;
 
+        }
+
+        self.canCopyContent = function () {
+            return localStorageService.isSupported;
+        };
+
+        self.canPasteContent = function () {
+            return localStorageService.isSupported;
+        };
+
+        self.setCopiedContent = function (itm) {
+            if (itm && itm.icContentTypeGuid) {
+                localStorageService.set("icContentTypeGuid", itm.icContentTypeGuid);
+                itm.key = undefined;
+                localStorageService.set("icContentJson", itm);
+                return true;
+            }
+            return false;
+        }
+
+        self.getCopiedContent = function () {
+            var itm = localStorageService.get("icContentJson");
+            itm.key = self.generateUid();
+            return itm;
+        }
+
+        self.getCopiedContentTypeGuid = function () {
+            return localStorageService.get("icContentTypeGuid");
         }
 
         // Helpful methods


### PR DESCRIPTION
Uses the localStorage API for copy & paste mechanism.

Ports over all the `localStorageService` API calls from https://github.com/umco/umbraco-stacked-content/pull/44

The function names feel verbose, but I didn't want to over simplify the naming with things "pasteContent", as the service library isn't pasting anything, it's purely retrieving from localStorage.

I've added another localStorage item for `"icContentTypeGuid"`, this is to make the content-type guid lookup more efficient, as previously we were getting the JSON blob, deserializing it only to get the guid. 

Happy to discuss all of this.