### PR TITLE
Added classes to the overlay/modal

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.js
@@ -156,14 +156,16 @@ angular.module("umbraco").controller("Our.Umbraco.InnerContent.Controllers.Inner
 angular.module("umbraco.directives").directive("innerContentOverlay", [
 
     "$q",
+    "overlayHelper",
     "innerContentService",
 
-    function ($q, innerContentService) {
+    function ($q, overlayHelper, innerContentService) {
 
         function link(scope, el, attr, ctrl) {
 
             scope.config.editorModels = scope.config.editorModels || {};
             scope.currentItem = null;
+            scope.overlayClasses = scope.overlayClasses || [];
 
             var getContentType = function (guid) {
                 return _.find(scope.config.contentTypes, function (ct) {
@@ -250,6 +252,7 @@ angular.module("umbraco.directives").directive("innerContentOverlay", [
                         scope.openContentEditorOverlay();
                     });
                 } else {
+                    setOverlayClasses("create");
                     scope.contentTypePickerOverlay.event = scope.config.event;
                     scope.contentTypePickerOverlay.show = true;
                 }
@@ -261,25 +264,41 @@ angular.module("umbraco.directives").directive("innerContentOverlay", [
             };
 
             scope.openContentEditorOverlay = function () {
+                setOverlayClasses(scope.config.propertyAlias, scope.currentItem.contentTypeAlias);
                 scope.contentEditorOverlay.title = "Edit " + scope.currentItem.contentTypeName;
                 scope.contentEditorOverlay.dialogData = { item: scope.currentItem };
                 scope.contentEditorOverlay.show = true;
             };
 
             scope.closeContentEditorOverlay = function () {
+                scope.overlayClasses = [];
                 scope.contentEditorOverlay.show = false;
             };
 
             scope.closeAllOverlays = function () {
+                scope.overlayClasses = [];
                 scope.closeContentTypePickerOverlay();
                 scope.closeContentEditorOverlay();
                 scope.config.show = false;
+            };
+
+            function setOverlayClasses() {
+                // Ensures that the "create" and "edit" classes don't conflict.
+                if (scope.overlayClasses.length > 1) {
+                    scope.overlayClasses.length = 1;
+                }
+                for (var i = 0; i < arguments.length; i++) {
+                    scope.overlayClasses.push("inner-content-overlay--" + arguments[i]);
+                }
             };
 
             var initOpen = function () {
 
                 // Map scaffolds to content type picker list
                 scope.contentTypePickerOverlay.availableItems = scope.config.contentTypePickerItems;
+
+                // Set the overlay class for the overlay's (overlapping) index
+                setOverlayClasses("overlay" + overlayHelper.getNumberOfOverlays());
 
                 // Open relevant dialog
                 if (!scope.config.data || !scope.config.data.model) {

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.overlay.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.overlay.html
@@ -1,4 +1,4 @@
-﻿<div class="inner-content-overlay">
+﻿<div class="inner-content-overlay" ng-class="overlayClasses">
 
     <umb-overlay ng-if="contentTypePickerOverlay.show"
                  model="contentTypePickerOverlay"


### PR DESCRIPTION
This enhancement adds class names to the overlay markup, this will allow  a developer to target CSS selectors for the following...

- Property Alias
- Document Type (of the Inner Content item)
- Overlay depth

For background on this enhancement, please see the Stacked Content ticket: https://github.com/umco/umbraco-stacked-content/issues/61